### PR TITLE
Feature/progression screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,7 +78,6 @@ android {
 }
 
 dependencies {
-
     implementation("androidx.core:core-ktx:1.12.0")
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("com.google.android.material:material:1.11.0")
@@ -114,6 +113,8 @@ dependencies {
     implementation("com.squareup.okhttp3:logging-interceptor:4.9.0")
 
     implementation("com.squareup.picasso:picasso:2.8")
+
+    implementation("com.jjoe64:graphview:4.2.2")
 }
 
 kapt {

--- a/app/src/main/java/com/example/healthconnect/codelab/data/datasource/DittoDatasource.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/datasource/DittoDatasource.kt
@@ -47,6 +47,22 @@ class DittoDatasource @Inject constructor(
         }
     }
 
+    suspend fun retrieveGeneralInfoFeatures(
+        googleId: String
+    ): Either<ResponseFailure, DittoGeneralInfoModel.Features?> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = dittoService.retrieveGeneralInfoFeatures(googleId)
+                if (response.code() == 404)
+                    Either.Right(null)
+                else
+                    ResponseParser.parseResponse(response)
+            } catch (e: Exception) {
+                ResponseParser.parseError(e)
+            }
+        }
+    }
+
     suspend fun retrieveSuggestedSessions(
         googleId: String
     ): Either<ResponseFailure, DittoGeneralInfoModel.TrainingPlanProperties?> {

--- a/app/src/main/java/com/example/healthconnect/codelab/data/datasource/DittoDatasource.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/datasource/DittoDatasource.kt
@@ -47,6 +47,22 @@ class DittoDatasource @Inject constructor(
         }
     }
 
+    suspend fun retrieveGeneralInfoFeatures(
+        googleId: String
+    ): Either<ResponseFailure, DittoGeneralInfoModel.Features?> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = dittoService.retrieveGeneralInfoFeatures(googleId)
+                if (response.code() == 404)
+                    Either.Right(null)
+                else
+                    ResponseParser.parseResponse(response)
+            } catch (e: Exception) {
+                ResponseParser.parseError(e)
+            }
+        }
+    }
+
     suspend fun retrieveSuggestedSessions(
         googleId: String
     ): Either<ResponseFailure, DittoGeneralInfoModel.TrainingPlanProperties?> {
@@ -101,6 +117,20 @@ class DittoDatasource @Inject constructor(
         return withContext(Dispatchers.IO) {
             try {
                 val response = dittoService.putGeneralInfoThing(thingId, thing)
+                ResponseParser.parseEmptyResponse(response)
+            } catch (e: Exception) {
+                ResponseParser.parseError(e)
+            }
+        }
+    }
+
+    suspend fun putGeneralInfoFeatures(
+        thingId: String,
+        features: DittoGeneralInfoModel.Features
+    ): Either<ResponseFailure, Unit> {
+        return withContext(Dispatchers.IO) {
+            try {
+                val response = dittoService.putGeneralInfoFeatures(thingId, features)
                 ResponseParser.parseEmptyResponse(response)
             } catch (e: Exception) {
                 ResponseParser.parseError(e)

--- a/app/src/main/java/com/example/healthconnect/codelab/data/model/ditto/DittoGeneralInfoModel.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/model/ditto/DittoGeneralInfoModel.kt
@@ -45,8 +45,15 @@ class DittoGeneralInfoModel {
     data class GoalProperties(
         var distance: Int,
         var seconds: Int,
-        var estimation: Int,
+        var estimations: List<Estimation>,
         var date: String
+    )
+
+    @Serializable
+    data class Estimation(
+        var date: String,
+        var seconds: Int,
+        var goalReachDate: String
     )
 
     @Serializable
@@ -76,7 +83,16 @@ class DittoGeneralInfoModel {
 
     @Serializable
     data class SuggestionsProperties(
-        val suggestions: List<GoalProperties>
+        val suggestions: List<Suggestion>
+    )
+
+    @Serializable
+    data class Suggestion(
+        val type: Int,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val distance: Int? = null,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val seconds: Int? = null,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val date: String? = null,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val trainingDays: List<Int>? = null
     )
 
     @Serializable
@@ -105,7 +121,10 @@ fun DittoGeneralInfo.Features.toData(): DittoGeneralInfoModel.Features =
     )
 
 fun DittoGeneralInfo.Goal.toData(): DittoGeneralInfoModel.GoalProperties =
-    DittoGeneralInfoModel.GoalProperties(distance, seconds, estimation, date.toString())
+    DittoGeneralInfoModel.GoalProperties(distance, seconds, estimations.map { it.toData() }, date.toString())
+
+fun DittoGeneralInfo.Estimation.toData() : DittoGeneralInfoModel.Estimation =
+    DittoGeneralInfoModel.Estimation(date.toString(), seconds, goalReachDate.toString())
 
 fun DittoGeneralInfo.TrainingPlan.toData(): DittoGeneralInfoModel.TrainingPlan =
     DittoGeneralInfoModel.TrainingPlan(
@@ -119,6 +138,42 @@ fun DittoGeneralInfo.Suggestions.toData(): DittoGeneralInfoModel.Suggestions =
     DittoGeneralInfoModel.Suggestions(
         DittoGeneralInfoModel.SuggestionsProperties(suggestions.map { it.toData() })
     )
+
+fun DittoGeneralInfo.Suggestion.toData(): DittoGeneralInfoModel.Suggestion {
+    return when (this) {
+        is DittoGeneralInfo.Suggestion.SmallerGoal -> {
+            DittoGeneralInfoModel.Suggestion(
+                type = type,
+                distance = distance,
+                seconds = seconds,
+                date = date.toString()
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.BiggerGoal -> {
+            DittoGeneralInfoModel.Suggestion(
+                type = type,
+                distance = distance,
+                seconds = seconds,
+                date = date.toString()
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.LessTrainingDays -> {
+            DittoGeneralInfoModel.Suggestion(
+                type = type,
+                trainingDays = trainingDays
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.MoreTrainingDays -> {
+            DittoGeneralInfoModel.Suggestion(
+                type = type,
+                trainingDays = trainingDays
+            )
+        }
+    }
+}
 
 fun DittoGeneralInfo.Preferences.toData(): DittoGeneralInfoModel.Preferences =
     DittoGeneralInfoModel.Preferences(

--- a/app/src/main/java/com/example/healthconnect/codelab/data/model/ditto/DittoGeneralInfoModel.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/model/ditto/DittoGeneralInfoModel.kt
@@ -45,8 +45,15 @@ class DittoGeneralInfoModel {
     data class GoalProperties(
         var distance: Int,
         var seconds: Int,
-        var estimation: Int,
+        var estimations: List<Estimation>,
         var date: String
+    )
+
+    @Serializable
+    data class Estimation(
+        var date: String,
+        var seconds: Int,
+        var goalReachDate: String
     )
 
     @Serializable
@@ -76,7 +83,17 @@ class DittoGeneralInfoModel {
 
     @Serializable
     data class SuggestionsProperties(
-        val suggestions: List<GoalProperties>
+        val suggestions: List<Suggestion>
+    )
+
+    @Serializable
+    data class Suggestion(
+        val id: Int,
+        val type: Int,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val distance: Int? = null,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val seconds: Int? = null,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val date: String? = null,
+        @EncodeDefault(EncodeDefault.Mode.NEVER) val trainingDays: List<Int>? = null
     )
 
     @Serializable
@@ -105,7 +122,10 @@ fun DittoGeneralInfo.Features.toData(): DittoGeneralInfoModel.Features =
     )
 
 fun DittoGeneralInfo.Goal.toData(): DittoGeneralInfoModel.GoalProperties =
-    DittoGeneralInfoModel.GoalProperties(distance, seconds, estimation, date.toString())
+    DittoGeneralInfoModel.GoalProperties(distance, seconds, estimations.map { it.toData() }, date.toString())
+
+fun DittoGeneralInfo.Estimation.toData() : DittoGeneralInfoModel.Estimation =
+    DittoGeneralInfoModel.Estimation(date.toString(), seconds, goalReachDate.toString())
 
 fun DittoGeneralInfo.TrainingPlan.toData(): DittoGeneralInfoModel.TrainingPlan =
     DittoGeneralInfoModel.TrainingPlan(
@@ -119,6 +139,46 @@ fun DittoGeneralInfo.Suggestions.toData(): DittoGeneralInfoModel.Suggestions =
     DittoGeneralInfoModel.Suggestions(
         DittoGeneralInfoModel.SuggestionsProperties(suggestions.map { it.toData() })
     )
+
+fun DittoGeneralInfo.Suggestion.toData(): DittoGeneralInfoModel.Suggestion {
+    return when (this) {
+        is DittoGeneralInfo.Suggestion.SmallerGoal -> {
+            DittoGeneralInfoModel.Suggestion(
+                id = id,
+                type = type,
+                distance = distance,
+                seconds = seconds,
+                date = date.toString()
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.BiggerGoal -> {
+            DittoGeneralInfoModel.Suggestion(
+                id = id,
+                type = type,
+                distance = distance,
+                seconds = seconds,
+                date = date.toString()
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.LessTrainingDays -> {
+            DittoGeneralInfoModel.Suggestion(
+                id = id,
+                type = type,
+                trainingDays = trainingDays
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.MoreTrainingDays -> {
+            DittoGeneralInfoModel.Suggestion(
+                id = id,
+                type = type,
+                trainingDays = trainingDays
+            )
+        }
+    }
+}
 
 fun DittoGeneralInfo.Preferences.toData(): DittoGeneralInfoModel.Preferences =
     DittoGeneralInfoModel.Preferences(

--- a/app/src/main/java/com/example/healthconnect/codelab/data/repository/DittoRepository.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/repository/DittoRepository.kt
@@ -33,12 +33,25 @@ class DittoRepository @Inject constructor(
         googleId: String
     ): Either<DittoError, DittoGeneralInfo.Thing?> {
         val response = dittoDatasource.retrieveGeneralInfoThing(googleId)
-        return response.fold(::handleError, ::handleGeneralInfo)
+        return response.fold(::handleError, ::handleGeneralInfoThing)
     }
 
-    private fun handleGeneralInfo(
+    private fun handleGeneralInfoThing(
         thing: DittoGeneralInfoModel.Thing?
     ): Either.Right<DittoGeneralInfo.Thing?> {
+        return Either.Right(thing?.toDomain())
+    }
+
+    suspend fun getGeneralInfoFeatures(
+        googleId: String
+    ): Either<DittoError, DittoGeneralInfo.Features?> {
+        val response = dittoDatasource.retrieveGeneralInfoFeatures(googleId)
+        return response.fold(::handleError, ::handleGeneralInfoFeatures)
+    }
+
+    private fun handleGeneralInfoFeatures(
+        thing: DittoGeneralInfoModel.Features?
+    ): Either.Right<DittoGeneralInfo.Features?> {
         return Either.Right(thing?.toDomain())
     }
 
@@ -79,6 +92,14 @@ class DittoRepository @Inject constructor(
         thing: DittoGeneralInfo.Thing
     ): Either<DittoError, Unit> {
         val response = dittoDatasource.putGeneralInfoThing(thing.thingId, thing.toData())
+        return response.fold(::handleError, ::handleEmptySuccess)
+    }
+
+    suspend fun putGeneralInfoFeatures(
+        thingId: String,
+        features: DittoGeneralInfo.Features
+    ): Either<DittoError, Unit> {
+        val response = dittoDatasource.putGeneralInfoFeatures(thingId, features.toData())
         return response.fold(::handleError, ::handleEmptySuccess)
     }
 

--- a/app/src/main/java/com/example/healthconnect/codelab/data/repository/DittoRepository.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/repository/DittoRepository.kt
@@ -33,12 +33,25 @@ class DittoRepository @Inject constructor(
         googleId: String
     ): Either<DittoError, DittoGeneralInfo.Thing?> {
         val response = dittoDatasource.retrieveGeneralInfoThing(googleId)
-        return response.fold(::handleError, ::handleGeneralInfo)
+        return response.fold(::handleError, ::handleGeneralInfoThing)
     }
 
-    private fun handleGeneralInfo(
+    private fun handleGeneralInfoThing(
         thing: DittoGeneralInfoModel.Thing?
     ): Either.Right<DittoGeneralInfo.Thing?> {
+        return Either.Right(thing?.toDomain())
+    }
+
+    suspend fun getGeneralInfoFeatures(
+        googleId: String
+    ): Either<DittoError, DittoGeneralInfo.Features?> {
+        val response = dittoDatasource.retrieveGeneralInfoFeatures(googleId)
+        return response.fold(::handleError, ::handleGeneralInfoFeatures)
+    }
+
+    private fun handleGeneralInfoFeatures(
+        thing: DittoGeneralInfoModel.Features?
+    ): Either.Right<DittoGeneralInfo.Features?> {
         return Either.Right(thing?.toDomain())
     }
 

--- a/app/src/main/java/com/example/healthconnect/codelab/data/service/DittoService.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/service/DittoService.kt
@@ -26,6 +26,11 @@ interface DittoService {
         @Path("googleId") googleId: String
     ): Response<ResponseBody>
 
+    @GET("/api/2/things/{googleId}/features")
+    suspend fun retrieveGeneralInfoFeatures(
+        @Path("googleId") googleId: String
+    ): Response<ResponseBody>
+
     @GET("/api/2/things/{googleId}/features/trainingPlan/properties")
     suspend fun retrieveSuggestedSessions(
         @Path("googleId") googleId: String
@@ -49,6 +54,13 @@ interface DittoService {
     suspend fun putGeneralInfoThing(
         @Path("googleId") googleId: String,
         @Body thing: DittoGeneralInfoModel.Thing
+    ): Response<ResponseBody>
+
+    @Headers("Content-Type: application/json")
+    @PUT("/api/2/things/{googleId}/features")
+    suspend fun putGeneralInfoFeatures(
+        @Path("googleId") googleId: String,
+        @Body features: DittoGeneralInfoModel.Features
     ): Response<ResponseBody>
 
     @DELETE("/api/2/things/{thingId}")

--- a/app/src/main/java/com/example/healthconnect/codelab/data/service/DittoService.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/data/service/DittoService.kt
@@ -26,6 +26,11 @@ interface DittoService {
         @Path("googleId") googleId: String
     ): Response<ResponseBody>
 
+    @GET("/api/2/things/{googleId}/features")
+    suspend fun retrieveGeneralInfoFeatures(
+        @Path("googleId") googleId: String
+    ): Response<ResponseBody>
+
     @GET("/api/2/things/{googleId}/features/trainingPlan/properties")
     suspend fun retrieveSuggestedSessions(
         @Path("googleId") googleId: String

--- a/app/src/main/java/com/example/healthconnect/codelab/domain/model/ditto/DittoGeneralInfo.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/domain/model/ditto/DittoGeneralInfo.kt
@@ -1,5 +1,6 @@
 package com.example.healthconnect.codelab.domain.model.ditto
 
+import android.util.Log
 import com.example.healthconnect.codelab.BuildConfig
 import com.example.healthconnect.codelab.data.model.ditto.DittoGeneralInfoModel
 import java.io.Serializable
@@ -32,8 +33,14 @@ class DittoGeneralInfo {
     data class Goal(
         var distance: Int,
         var seconds: Int,
-        var estimation: Int,
+        var estimations: List<Estimation>,
         var date: LocalDate
+    )
+
+    data class Estimation(
+        var date: LocalDate,
+        var seconds: Int,
+        var goalReachDate: LocalDate
     )
 
     data class TrainingPlan(
@@ -50,8 +57,34 @@ class DittoGeneralInfo {
     ) : Serializable
 
     data class Suggestions(
-        val suggestions: List<Goal>
+        var suggestions: List<Suggestion>
     )
+
+    sealed class Suggestion(open val id: Int, val type: Int) {
+        data class SmallerGoal(
+            override val id: Int,
+            val distance: Int,
+            val seconds: Int,
+            val date: LocalDate
+        ) : Suggestion(id,0)
+
+        data class BiggerGoal(
+            override val id: Int,
+            val distance: Int,
+            val seconds: Int,
+            val date: LocalDate
+        ) : Suggestion(id,1)
+
+        data class LessTrainingDays(
+            override val id: Int,
+            val trainingDays: List<Int>
+        ) : Suggestion(id,2)
+
+        data class MoreTrainingDays(
+            override val id: Int,
+            val trainingDays: List<Int>
+        ) : Suggestion(id,3)
+    }
 
     data class Preferences(
         var trainingDays: List<Int>
@@ -82,9 +115,12 @@ fun DittoGeneralInfoModel.GoalProperties.toDomain(): DittoGeneralInfo.Goal =
     DittoGeneralInfo.Goal(
         distance,
         seconds,
-        estimation,
+        estimations.map { it.toDomain() },
         LocalDate.parse(date)
     )
+
+fun DittoGeneralInfoModel.Estimation.toDomain(): DittoGeneralInfo.Estimation =
+    DittoGeneralInfo.Estimation(LocalDate.parse(date), seconds, LocalDate.parse(goalReachDate))
 
 fun DittoGeneralInfoModel.TrainingPlan.toDomain(): DittoGeneralInfo.TrainingPlan =
     DittoGeneralInfo.TrainingPlan(properties.sessions.map { it.toDomain() })
@@ -99,6 +135,36 @@ fun DittoGeneralInfoModel.TrainingSession.toDomain(): DittoGeneralInfo.TrainingS
 
 fun DittoGeneralInfoModel.Suggestions.toDomain(): DittoGeneralInfo.Suggestions =
     DittoGeneralInfo.Suggestions(properties.suggestions.map { it.toDomain() })
+
+fun DittoGeneralInfoModel.Suggestion.toDomain(): DittoGeneralInfo.Suggestion {
+    return when (type) {
+        0 -> {
+            DittoGeneralInfo.Suggestion.SmallerGoal(
+                id, distance!!, seconds!!, LocalDate.parse(date!!)
+            )
+        }
+
+        1 -> {
+            DittoGeneralInfo.Suggestion.BiggerGoal(
+                id, distance!!, seconds!!, LocalDate.parse(date!!)
+            )
+        }
+
+        2 -> {
+            DittoGeneralInfo.Suggestion.LessTrainingDays(id, trainingDays!!)
+        }
+
+        3 -> {
+            DittoGeneralInfo.Suggestion.LessTrainingDays(id, trainingDays!!)
+        }
+
+        else -> {
+            DittoGeneralInfo.Suggestion.SmallerGoal(
+                id, distance!!, seconds!!, LocalDate.parse(date!!)
+            )
+        }
+    }
+}
 
 fun DittoGeneralInfoModel.Preferences.toDomain(): DittoGeneralInfo.Preferences =
     DittoGeneralInfo.Preferences(properties.trainingDays)

--- a/app/src/main/java/com/example/healthconnect/codelab/domain/usecase/ditto/get/generalInfo/GetGeneralInfoFeatures.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/domain/usecase/ditto/get/generalInfo/GetGeneralInfoFeatures.kt
@@ -1,0 +1,16 @@
+package com.example.healthconnect.codelab.domain.usecase.ditto.get.generalInfo
+
+import arrow.core.Either
+import com.example.healthconnect.codelab.data.repository.DittoRepository
+import com.example.healthconnect.codelab.domain.model.ditto.DittoError
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.domain.usecase.SuspendUseCase
+import javax.inject.Inject
+
+class GetGeneralInfoFeatures @Inject constructor(
+    private val repository: DittoRepository
+) : SuspendUseCase<String, DittoError, DittoGeneralInfo.Features?>() {
+    override suspend fun run(params: String): Either<DittoError, DittoGeneralInfo.Features?> {
+        return repository.getGeneralInfoFeatures(DittoGeneralInfo.thingId(params))
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/domain/usecase/ditto/put/generalInfo/PutGeneralInfoFeatures.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/domain/usecase/ditto/put/generalInfo/PutGeneralInfoFeatures.kt
@@ -1,0 +1,24 @@
+package com.example.healthconnect.codelab.domain.usecase.ditto.put.generalInfo
+
+import arrow.core.Either
+import com.example.healthconnect.codelab.data.repository.DittoRepository
+import com.example.healthconnect.codelab.domain.model.ditto.DittoError
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.domain.usecase.SuspendUseCase
+import javax.inject.Inject
+
+class PutGeneralInfoFeatures @Inject constructor(
+    private val repository: DittoRepository
+) : SuspendUseCase<PutGeneralInfoFeaturesParams, DittoError, Unit>() {
+    override suspend fun run(params: PutGeneralInfoFeaturesParams): Either<DittoError, Unit> {
+        return repository.putGeneralInfoFeatures(
+            DittoGeneralInfo.thingId(params.googleId),
+            params.features
+        )
+    }
+}
+
+data class PutGeneralInfoFeaturesParams(
+    val googleId: String,
+    val features: DittoGeneralInfo.Features
+)

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/home/HomeFragment.kt
@@ -134,8 +134,8 @@ class HomeFragment : Fragment() {
     }
 
     private fun moveToProgression() {
-        //val action = HomeFragmentDirections
-        //findNavController().navigate(action)
+        val action = HomeFragmentDirections.actionHomeFragmentToProgressionFragment()
+        findNavController().navigate(action)
     }
 
     private fun moveToNextSession() {
@@ -163,7 +163,7 @@ class HomeFragment : Fragment() {
                     registerForActivityResult(hcManager.requestPermissionActivityContract()) {
                         if (it.containsAll(hcManager.permissions)) launchService()
                         else {
-                            ViewUtils.showWarningDialog(
+                            ViewUtils.showDialog(
                                 requireContext(),
                                 R.string.permissions_alert_dialog,
                                 {},

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/home/HomeFragment.kt
@@ -134,8 +134,8 @@ class HomeFragment : Fragment() {
     }
 
     private fun moveToProgression() {
-        //val action = HomeFragmentDirections
-        //findNavController().navigate(action)
+        val action = HomeFragmentDirections.actionHomeFragmentToProgressionFragment()
+        findNavController().navigate(action)
     }
 
     private fun moveToNextSession() {

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/home/adapter/HomeAdapter.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/home/adapter/HomeAdapter.kt
@@ -71,7 +71,7 @@ class HomeAdapter : RecyclerView.Adapter<HomeAdapter.ViewHolder>() {
 
                     tvTime.text = goal.seconds.toTimeString()
                     tvDistance.text = goal.distance.toDistanceString()
-                    tvEstimation.text = goal.estimation.toTimeString()
+                    tvEstimation.text = goal.estimations.lastOrNull()?.seconds?.toTimeString() ?: "-"
                     tvDate.text = goal.date.toString()
 
                     constraint.visibility = View.VISIBLE

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionFragment.kt
@@ -1,0 +1,163 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.healthconnect.codelab.R
+import com.example.healthconnect.codelab.databinding.FragmentProgressionBinding
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.ui.MainActivity
+import com.example.healthconnect.codelab.utils.ViewUtils
+import com.example.healthconnect.codelab.utils.toDistanceString
+import com.example.healthconnect.codelab.utils.toSpeedString
+import com.example.healthconnect.codelab.utils.toTimeString
+import com.jjoe64.graphview.DefaultLabelFormatter
+import com.jjoe64.graphview.series.DataPoint
+import com.jjoe64.graphview.series.LineGraphSeries
+import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
+import kotlin.math.absoluteValue
+
+@AndroidEntryPoint
+class ProgressionFragment : Fragment() {
+
+    private var _binding: FragmentProgressionBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ProgressionViewModel by viewModels()
+
+    private val lineSeries = LineGraphSeries<DataPoint>(arrayOf())
+    private val adapter = SuggestionsAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentProgressionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (activity as MainActivity).apply {
+            showNavbar(true)
+            showToolbar(R.string.title_progression, false)
+        }
+
+        initViews()
+        initViewModel()
+    }
+
+    private fun initViews() = binding.apply {
+        swipeRefreshLayout.isRefreshing = true
+        swipeRefreshLayout.setOnRefreshListener {
+            viewModel.init()
+        }
+
+        graph.addSeries(lineSeries)
+
+        initSuggestionsRecycler()
+    }
+
+    private fun initViewModel() = viewModel.apply {
+        features.observe(viewLifecycleOwner) {
+            binding.apply {
+                if (it == null || it.goal.estimations.isEmpty()) {
+                    tvEmptyState.text = getString(R.string.progression_empty_state)
+
+                    tvEmptyState.visibility = View.VISIBLE
+                    scrollView.visibility = View.GONE
+                } else {
+                    bindGraph(it.goal.estimations)
+                    bindCurrentEstimation(it.goal)
+
+                    if (it.suggestions.suggestions.isEmpty()) {
+                        tvSuggestions.visibility = View.GONE
+                        rvSuggestions.visibility = View.GONE
+                    } else {
+                        updateSuggestions(it.suggestions.suggestions)
+                        tvSuggestions.visibility = View.VISIBLE
+                        rvSuggestions.visibility = View.VISIBLE
+                    }
+
+                    tvEmptyState.visibility = View.GONE
+                    scrollView.visibility = View.VISIBLE
+                }
+            }
+            dismissLoader()
+        }
+
+        error.observe(viewLifecycleOwner) {
+            binding.apply {
+                tvEmptyState.text = getString(ViewUtils.getErrorStringId(it.failure))
+
+                tvEmptyState.visibility = View.VISIBLE
+                scrollView.visibility = View.GONE
+            }
+            dismissLoader()
+        }
+
+        init()
+    }
+
+    private fun dismissLoader() {
+        binding.swipeRefreshLayout.isRefreshing = false
+    }
+
+    private fun bindGraph(estimations: List<DittoGeneralInfo.Estimation>) = binding.apply {
+        lineSeries.resetData(
+            estimations.map {
+                DataPoint(it.date.toEpochDay().toDouble(), (-1*it.seconds).toDouble())
+            }.toTypedArray()
+        )
+        graph.gridLabelRenderer.labelFormatter = LabelFormatter()
+        graph.gridLabelRenderer.numHorizontalLabels = 3
+        graph.gridLabelRenderer.setHumanRounding(false)
+
+        graph.viewport.isScrollable = true
+        graph.viewport.isXAxisBoundsManual = true
+        graph.viewport.setMaxX(estimations.last().date.plusDays(1).toEpochDay().toDouble())
+        graph.viewport.setMinX(estimations.first().date.minusDays(1).toEpochDay().toDouble())
+
+        graph.viewport.isYAxisBoundsManual = true
+        graph.viewport.setMaxY((estimations.minOf { it.seconds }*-1).toDouble())
+        graph.viewport.setMinY((estimations.maxOf { it.seconds }*-1).toDouble())
+    }
+
+    private fun bindCurrentEstimation(goal: DittoGeneralInfo.Goal) = binding.apply {
+        val estimation = goal.estimations.last()
+        tvEstimation.text = "${estimation.seconds.toTimeString()} ${getString(R.string.estimation_part_1)}" +
+                " ${goal.distance.toDistanceString()} (${((goal.seconds.toDouble()/60) / (goal.distance.toDouble()/1000)).toSpeedString()})"
+
+        tvGoalDate.text = "${getString(R.string.goal_date_part_1)} ${goal.estimations.last().goalReachDate}"
+    }
+
+    private fun initSuggestionsRecycler() = binding.apply {
+        rvSuggestions.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        rvSuggestions.adapter = adapter
+    }
+
+    private fun updateSuggestions(suggestions: List<DittoGeneralInfo.Suggestion>) {
+        adapter.submitList(
+            suggestions.map {
+                it.toPresentation(requireContext(), findNavController())
+            }
+        )
+    }
+
+    private class LabelFormatter : DefaultLabelFormatter() {
+        override fun formatLabel(value: Double, isValueX: Boolean): String {
+            return if (isValueX) {
+                LocalDate.ofEpochDay(value.toLong()).toString()
+            } else {
+                value.absoluteValue.toInt().toTimeString()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionFragment.kt
@@ -1,0 +1,224 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.example.healthconnect.codelab.R
+import com.example.healthconnect.codelab.databinding.FragmentProgressionBinding
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.ui.MainActivity
+import com.example.healthconnect.codelab.ui.progression.model.SuggestionViewEntity
+import com.example.healthconnect.codelab.ui.progression.model.toPresentation
+import com.example.healthconnect.codelab.utils.ViewUtils
+import com.example.healthconnect.codelab.utils.toDistanceString
+import com.example.healthconnect.codelab.utils.toSpeedString
+import com.example.healthconnect.codelab.utils.toTimeString
+import com.jjoe64.graphview.DefaultLabelFormatter
+import com.jjoe64.graphview.series.DataPoint
+import com.jjoe64.graphview.series.LineGraphSeries
+import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalDate
+import kotlin.math.absoluteValue
+
+@AndroidEntryPoint
+class ProgressionFragment : Fragment() {
+
+    private var _binding: FragmentProgressionBinding? = null
+    private val binding get() = _binding!!
+
+    private val viewModel: ProgressionViewModel by viewModels()
+
+    private val lineSeries = LineGraphSeries<DataPoint>(arrayOf())
+    private val adapter = SuggestionsAdapter(::onSuggestionClick)
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentProgressionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        (activity as MainActivity).apply {
+            showNavbar(true)
+            showToolbar(R.string.title_progression, false)
+        }
+
+        initViews()
+        initViewModel()
+    }
+
+    private fun initViews() = binding.apply {
+        swipeRefreshLayout.isRefreshing = true
+        swipeRefreshLayout.setOnRefreshListener {
+            viewModel.init()
+        }
+
+        graph.addSeries(lineSeries)
+
+        initSuggestionsRecycler()
+    }
+
+    private fun initViewModel() = viewModel.apply {
+        features.observe(viewLifecycleOwner) {
+            binding.apply {
+                if (it == null || it.goal.estimations.isEmpty()) {
+                    tvEmptyState.text = getString(R.string.progression_empty_state)
+
+                    tvEmptyState.visibility = View.VISIBLE
+                    scrollView.visibility = View.GONE
+                } else {
+                    bindGraph(it.goal.estimations)
+                    bindCurrentEstimation(it.goal)
+
+                    if (it.suggestions.suggestions.isEmpty()) {
+                        tvSuggestions.visibility = View.GONE
+                        rvSuggestions.visibility = View.GONE
+                    } else {
+                        updateSuggestions(it.suggestions.suggestions)
+                        tvSuggestions.visibility = View.VISIBLE
+                        rvSuggestions.visibility = View.VISIBLE
+                    }
+
+                    tvEmptyState.visibility = View.GONE
+                    scrollView.visibility = View.VISIBLE
+                }
+            }
+            dismissLoader()
+        }
+
+        error.observe(viewLifecycleOwner) {
+            binding.apply {
+                tvEmptyState.text = getString(ViewUtils.getErrorStringId(it.failure))
+
+                tvEmptyState.visibility = View.VISIBLE
+                scrollView.visibility = View.GONE
+            }
+            dismissLoader()
+        }
+
+        putFeaturesSuccess.observe(viewLifecycleOwner) {
+            if (it) {
+                ViewUtils.showToast(requireContext(), R.string.put_features_success)
+                putFeaturesSuccess.postValue(false)
+            }
+        }
+
+        putFeaturesError.observe(viewLifecycleOwner) {
+            if (it != null) {
+                ViewUtils.showToast(requireContext(), ViewUtils.getErrorStringId(it.failure))
+                putFeaturesError.postValue(null)
+            }
+        }
+
+        init()
+    }
+
+    private fun dismissLoader() {
+        binding.swipeRefreshLayout.isRefreshing = false
+    }
+
+    private fun bindGraph(estimations: List<DittoGeneralInfo.Estimation>) = binding.apply {
+        lineSeries.resetData(
+            estimations.map {
+                DataPoint(it.date.toEpochDay().toDouble(), (-1*it.seconds).toDouble())
+            }.toTypedArray()
+        )
+        graph.gridLabelRenderer.labelFormatter = LabelFormatter()
+        graph.gridLabelRenderer.numHorizontalLabels = 3
+        graph.gridLabelRenderer.setHumanRounding(false)
+
+        graph.viewport.isScrollable = true
+        graph.viewport.isXAxisBoundsManual = true
+        graph.viewport.setMaxX(estimations.last().date.plusDays(1).toEpochDay().toDouble())
+        graph.viewport.setMinX(estimations.first().date.minusDays(1).toEpochDay().toDouble())
+
+        graph.viewport.isYAxisBoundsManual = true
+        graph.viewport.setMaxY((estimations.minOf { it.seconds }*-1).toDouble())
+        graph.viewport.setMinY((estimations.maxOf { it.seconds }*-1).toDouble())
+    }
+
+    private fun bindCurrentEstimation(goal: DittoGeneralInfo.Goal) = binding.apply {
+        val estimation = goal.estimations.last()
+        tvEstimation.text = "${estimation.seconds.toTimeString()} ${getString(R.string.estimation_part_1)}" +
+                " ${goal.distance.toDistanceString()} (${((estimation.seconds.toDouble()/60) / (goal.distance.toDouble()/1000)).toSpeedString()})"
+
+        tvGoalDate.text = "${getString(R.string.goal_date_part_1)} ${goal.estimations.last().goalReachDate}"
+    }
+
+    private fun initSuggestionsRecycler() = binding.apply {
+        rvSuggestions.layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+        rvSuggestions.adapter = adapter
+    }
+
+    private fun updateSuggestions(suggestions: List<DittoGeneralInfo.Suggestion>) {
+        adapter.submitList(
+            suggestions.map {
+                it.toPresentation(requireContext())
+            },
+        )
+    }
+
+    private fun onSuggestionClick(item: SuggestionViewEntity) {
+        when (item.suggestion) {
+            is DittoGeneralInfo.Suggestion.SmallerGoal -> {
+                ViewUtils.showDialog(requireContext(), item.description, { changeGoal(item.suggestion.id, item.suggestion.distance, item.suggestion.seconds, item.suggestion.date) }) {}
+            }
+
+            is DittoGeneralInfo.Suggestion.BiggerGoal -> {
+                ViewUtils.showDialog(requireContext(), item.description, { changeGoal(item.suggestion.id, item.suggestion.distance, item.suggestion.seconds, item.suggestion.date) }) {}
+            }
+
+            is DittoGeneralInfo.Suggestion.LessTrainingDays -> {
+                ViewUtils.showDialog(requireContext(), item.description, { changeTrainingDays(item.suggestion.id, item.suggestion.trainingDays) }) {}
+            }
+
+            is DittoGeneralInfo.Suggestion.MoreTrainingDays -> {
+                ViewUtils.showDialog(requireContext(), item.description, { changeTrainingDays(item.suggestion.id,   item.suggestion.trainingDays) }) {}
+            }
+        }
+    }
+
+    private fun changeGoal(id: Int, distance: Int, seconds: Int, date: LocalDate) {
+        val modifiedFeatures = viewModel.features.value?.let {
+            it.goal.distance = distance
+            it.goal.seconds = seconds
+            it.goal.date = date
+            it.suggestions.suggestions = it.suggestions.suggestions.filter { it.id != id }
+            it
+        }
+        viewModel.putGeneralInfoFeatures(
+            viewModel.googleId.value!!,
+            modifiedFeatures!!
+        )
+    }
+
+    private fun changeTrainingDays(id: Int, days: List<Int>) {
+        val modifiedFeatures = viewModel.features.value?.let {
+            it.preferences.trainingDays = days
+            it.suggestions.suggestions = it.suggestions.suggestions.filter { it.id != id }
+            it
+        }
+        viewModel.putGeneralInfoFeatures(
+            viewModel.googleId.value!!,
+            modifiedFeatures!!
+        )
+    }
+
+    private class LabelFormatter : DefaultLabelFormatter() {
+        override fun formatLabel(value: Double, isValueX: Boolean): String {
+            return if (isValueX) {
+                LocalDate.ofEpochDay(value.toLong()).toString()
+            } else {
+                value.absoluteValue.toInt().toTimeString()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionViewModel.kt
@@ -1,0 +1,99 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.healthconnect.codelab.data.model.failure.ResponseFailure
+import com.example.healthconnect.codelab.domain.model.ditto.DittoError
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.domain.usecase.ditto.get.generalInfo.GetGeneralInfoFeatures
+import com.example.healthconnect.codelab.domain.usecase.ditto.put.generalInfo.PutGeneralInfoFeatures
+import com.example.healthconnect.codelab.domain.usecase.ditto.put.generalInfo.PutGeneralInfoFeaturesParams
+import com.example.healthconnect.codelab.domain.usecase.userInformation.ReadGoogleId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ProgressionViewModel @Inject constructor(
+    private val getGeneralInfoFeatures: GetGeneralInfoFeatures,
+    private val readGoogleId: ReadGoogleId,
+    private val putGeneralInfoFeatures: PutGeneralInfoFeatures
+) : ViewModel() {
+
+    private var _features = MutableLiveData<DittoGeneralInfo.Features?>()
+    val features get() = _features
+
+    private var _googleId = MutableLiveData<String>()
+    val googleId get() = _googleId
+
+    private var _error = MutableLiveData<DittoError>()
+    val error get() = _error
+
+    val putFeaturesSuccess = MutableLiveData<Boolean>()
+
+    val putFeaturesError = MutableLiveData<DittoError?>()
+
+    fun init() {
+        getGoogleId()
+    }
+
+    fun getFeatures(googleId: String) {
+        viewModelScope.launch {
+            getGeneralInfoFeatures(googleId) {
+                it.fold(::handleFeaturesError, ::handleFeaturesSuccess)
+            }
+        }
+    }
+
+    private fun handleFeaturesError(error: DittoError) {
+        _error.postValue(error)
+    }
+
+    private fun handleFeaturesSuccess(info: DittoGeneralInfo.Features?) {
+        _features.postValue(info)
+    }
+
+    private fun getGoogleId() {
+        viewModelScope.launch {
+            readGoogleId(Unit) {
+                it.fold(::handleGoogleIdError, ::handleGoogleIdSuccess)
+            }
+        }
+    }
+
+    private fun handleGoogleIdError(unit: Unit) {
+        _error.postValue(DittoError(ResponseFailure.UnknownError))
+    }
+
+    private fun handleGoogleIdSuccess(googleId: Flow<String>) {
+        viewModelScope.launch {
+            googleId.collect {
+                getFeatures(it)
+                _googleId.postValue(it)
+            }
+        }
+    }
+
+    fun putGeneralInfoFeatures(
+        googleId: String,
+        modifiedFeatures: DittoGeneralInfo.Features
+    ) {
+        val params = PutGeneralInfoFeaturesParams(googleId, modifiedFeatures)
+        viewModelScope.launch {
+            putGeneralInfoFeatures(params) {
+                it.fold(::handlePutFeaturesError, ::handlePutFeaturesSuccess)
+            }
+        }
+    }
+
+    private fun handlePutFeaturesError(error: DittoError) {
+        putFeaturesError.postValue(error)
+    }
+
+    private fun handlePutFeaturesSuccess(unit: Unit) {
+        putFeaturesSuccess.postValue(true)
+        init()
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionViewModel.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/ProgressionViewModel.kt
@@ -1,0 +1,69 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.healthconnect.codelab.data.model.failure.ResponseFailure
+import com.example.healthconnect.codelab.domain.model.ditto.DittoError
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.domain.usecase.ditto.get.generalInfo.GetGeneralInfoFeatures
+import com.example.healthconnect.codelab.domain.usecase.userInformation.ReadGoogleId
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ProgressionViewModel @Inject constructor(
+    private val getGeneralInfoFeatures: GetGeneralInfoFeatures,
+    private val readGoogleId: ReadGoogleId
+) : ViewModel() {
+
+    private var _features = MutableLiveData<DittoGeneralInfo.Features?>()
+    val features get() = _features
+
+    private var _error = MutableLiveData<DittoError>()
+    val error get() = _error
+
+
+
+    fun init() {
+        getGoogleId()
+    }
+
+    fun getFeatures(googleId: String) {
+        viewModelScope.launch {
+            getGeneralInfoFeatures(googleId) {
+                it.fold(::handleFeaturesError, ::handleFeaturesSuccess)
+            }
+        }
+    }
+
+    private fun handleFeaturesError(error: DittoError) {
+        _error.postValue(error)
+    }
+
+    private fun handleFeaturesSuccess(info: DittoGeneralInfo.Features?) {
+        _features.postValue(info)
+    }
+
+    private fun getGoogleId() {
+        viewModelScope.launch {
+            readGoogleId(Unit) {
+                it.fold(::handleGoogleIdError, ::handleGoogleIdSuccess)
+            }
+        }
+    }
+
+    private fun handleGoogleIdError(unit: Unit) {
+        _error.postValue(DittoError(ResponseFailure.UnknownError))
+    }
+
+    private fun handleGoogleIdSuccess(googleId: Flow<String>) {
+        viewModelScope.launch {
+            googleId.collect {
+                getFeatures(it)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/SuggestionViewEntity.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/SuggestionViewEntity.kt
@@ -1,0 +1,49 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import android.content.Context
+import androidx.navigation.NavController
+import com.example.healthconnect.codelab.R
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.utils.toDistanceString
+import com.example.healthconnect.codelab.utils.toTimeString
+
+data class SuggestionViewEntity(
+    val description: String,
+    val callback: () -> Unit
+)
+
+fun DittoGeneralInfo.Suggestion.toPresentation(context: Context, navController: NavController): SuggestionViewEntity {
+    return when (this) {
+        is DittoGeneralInfo.Suggestion.SmallerGoal -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.smaller_goal_1)} ${this.seconds.toTimeString()} ${context.getString(R.string.smaller_goal_2)} ${this.distance.toDistanceString()}?"
+            ) {
+
+            }
+        }
+
+        is DittoGeneralInfo.Suggestion.BiggerGoal -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.bigger_goal_1)} ${this.seconds.toTimeString()} ${context.getString(R.string.bigger_goal_2)} ${this.distance.toDistanceString()}?"
+            ) {
+
+            }
+        }
+
+        is DittoGeneralInfo.Suggestion.LessTrainingDays -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.less_training_days_1)} ${this.trainingDays.size} ${context.getString(R.string.less_training_days_2)}"
+            ) {
+
+            }
+        }
+
+        is DittoGeneralInfo.Suggestion.MoreTrainingDays -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.more_training_days_1)} ${this.trainingDays.size} ${context.getString(R.string.more_training_days_2)}"
+            ) {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/SuggestionsAdapter.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/SuggestionsAdapter.kt
@@ -1,0 +1,44 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.healthconnect.codelab.databinding.ItemSuggestionsListBinding
+
+class SuggestionsAdapter(
+
+) : RecyclerView.Adapter<SuggestionsAdapter.ViewHolder>() {
+
+    private var list: List<SuggestionViewEntity> = emptyList()
+
+    class ViewHolder(
+        private val binding: ItemSuggestionsListBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: SuggestionViewEntity) = binding.apply {
+            root.setOnClickListener { item.callback() }
+            tvSuggestion.text = item.description
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            ItemSuggestionsListBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            )
+        )
+    }
+
+    override fun getItemCount() = list.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(list[position])
+    }
+
+    fun submitList(list: List<SuggestionViewEntity>) {
+        this.list = list
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/SuggestionsAdapter.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/SuggestionsAdapter.kt
@@ -1,0 +1,47 @@
+package com.example.healthconnect.codelab.ui.progression
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.example.healthconnect.codelab.databinding.ItemSuggestionsListBinding
+import com.example.healthconnect.codelab.ui.progression.model.SuggestionViewEntity
+
+class SuggestionsAdapter(
+    private val onSuggestionClick: (SuggestionViewEntity) -> Unit
+) : RecyclerView.Adapter<SuggestionsAdapter.ViewHolder>() {
+
+    private var list: List<SuggestionViewEntity> = emptyList()
+
+    class ViewHolder(
+        private val binding: ItemSuggestionsListBinding,
+        private val onSuggestionClick: (SuggestionViewEntity) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: SuggestionViewEntity) = binding.apply {
+            root.setOnClickListener { onSuggestionClick(item) }
+            tvSuggestion.text = item.description
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        return ViewHolder(
+            ItemSuggestionsListBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            ),
+            onSuggestionClick
+        )
+    }
+
+    override fun getItemCount() = list.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(list[position])
+    }
+
+    fun submitList(list: List<SuggestionViewEntity>) {
+        this.list = list
+        notifyDataSetChanged()
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/progression/model/SuggestionViewEntity.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/progression/model/SuggestionViewEntity.kt
@@ -1,0 +1,44 @@
+package com.example.healthconnect.codelab.ui.progression.model
+
+import android.content.Context
+import com.example.healthconnect.codelab.R
+import com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo
+import com.example.healthconnect.codelab.utils.toDistanceString
+import com.example.healthconnect.codelab.utils.toTimeString
+
+data class SuggestionViewEntity(
+    val description: String,
+    val suggestion: DittoGeneralInfo.Suggestion
+)
+
+fun DittoGeneralInfo.Suggestion.toPresentation(context: Context): SuggestionViewEntity {
+    return when (this) {
+        is DittoGeneralInfo.Suggestion.SmallerGoal -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.smaller_goal_1)} ${this.seconds.toTimeString()} ${context.getString(R.string.smaller_goal_2)} ${this.distance.toDistanceString()}?",
+                this
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.BiggerGoal -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.bigger_goal_1)} ${this.seconds.toTimeString()} ${context.getString(R.string.bigger_goal_2)} ${this.distance.toDistanceString()}?",
+                this
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.LessTrainingDays -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.less_training_days_1)} ${this.trainingDays.size} ${context.getString(R.string.less_training_days_2)}",
+                this
+            )
+        }
+
+        is DittoGeneralInfo.Suggestion.MoreTrainingDays -> {
+            SuggestionViewEntity(
+                "${context.getString(R.string.more_training_days_1)} ${this.trainingDays.size} ${context.getString(R.string.more_training_days_2)}",
+                this
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/settings/SettingsFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -52,10 +50,10 @@ class SettingsFragment : Fragment() {
         val settingsList =
             listOf(
                 SettingsViewEntity.RegularSetting(getString(R.string.logout)) {
-                    ViewUtils.showWarningDialog(requireContext(), R.string.logout_warning_dialog, ::onLogout, {})
+                    ViewUtils.showDialog(requireContext(), R.string.logout_warning_dialog, ::onLogout, {})
                 },
                 SettingsViewEntity.DangerousSetting(getString(R.string.delete_account)) {
-                    ViewUtils.showWarningDialog(requireContext(), R.string.delete_account_warning_dialog, ::onDeleteAccount, {})
+                    ViewUtils.showDialog(requireContext(), R.string.delete_account_warning_dialog, ::onDeleteAccount, {})
                 }
             )
 

--- a/app/src/main/java/com/example/healthconnect/codelab/utils/ViewUtils.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/utils/ViewUtils.kt
@@ -1,15 +1,20 @@
 package com.example.healthconnect.codelab.utils
 
 import android.content.Context
+import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import com.example.healthconnect.codelab.R
 import com.example.healthconnect.codelab.data.model.failure.ResponseFailure
 
 object ViewUtils {
 
-    fun showWarningDialog(context: Context, resId: Int, successCallback: () -> Unit, cancelCallback: () -> Unit) {
+    fun showDialog(context: Context, resId: Int, successCallback: () -> Unit, cancelCallback: () -> Unit) {
+        showDialog(context, context.getString(resId), successCallback, cancelCallback)
+    }
+
+    fun showDialog(context: Context, message: String, successCallback: () -> Unit, cancelCallback: () -> Unit) {
         val builder = AlertDialog.Builder(context)
-        builder.setMessage(resId)
+        builder.setMessage(message)
         builder.setPositiveButton(R.string.ok) { dialog, id ->
             successCallback.invoke()
         }
@@ -17,6 +22,14 @@ object ViewUtils {
             cancelCallback.invoke()
         }
         builder.show()
+    }
+
+    fun showToast(context: Context, resId: Int) {
+        showToast(context, context.getString(resId))
+    }
+
+    fun showToast(context: Context, message: String) {
+        Toast.makeText(context, message, Toast.LENGTH_LONG).show()
     }
 
     fun getErrorStringId(r: ResponseFailure): Int {

--- a/app/src/main/res/drawable/icons8_info.xml
+++ b/app/src/main/res/drawable/icons8_info.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="50dp"
+    android:height="50dp"
+    android:viewportWidth="50"
+    android:viewportHeight="50">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M25,2C12.309,2 2,12.309 2,25C2,37.691 12.309,48 25,48C37.691,48 48,37.691 48,25C48,12.309 37.691,2 25,2zM25,4C36.61,4 46,13.39 46,25C46,36.61 36.61,46 25,46C13.39,46 4,36.61 4,25C4,13.39 13.39,4 25,4zM25,11A3,3 0,0 0,22 14A3,3 0,0 0,25 17A3,3 0,0 0,28 14A3,3 0,0 0,25 11zM21,21L21,23L22,23L23,23L23,36L22,36L21,36L21,38L22,38L23,38L27,38L28,38L29,38L29,36L28,36L27,36L27,21L26,21L22,21L21,21z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_progression.xml
+++ b/app/src/main/res/layout/fragment_progression.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.progression.ProgressionFragment">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_marginTop="5dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.core.widget.NestedScrollView
+            android:id="@+id/scrollView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/graphCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/default_horizontal_margin"
+                    android:layout_marginBottom="@dimen/activity_vertical_margin"
+                    app:cardCornerRadius="@dimen/default_card_corner_radius">
+
+                    <com.jjoe64.graphview.GraphView
+                        android:id="@+id/graph"
+                        android:layout_width="match_parent"
+                        android:layout_height="@dimen/chart_height"
+                        android:layout_margin="@dimen/default_horizontal_margin" />
+
+                </androidx.cardview.widget.CardView>
+
+                <TextView
+                    style="@style/TitleText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/default_horizontal_margin"
+                    android:layout_marginBottom="@dimen/activity_vertical_margin"
+                    android:text="@string/current_estimation" />
+
+                <androidx.cardview.widget.CardView
+                    android:id="@+id/estimationCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/default_horizontal_margin"
+                    android:layout_marginBottom="@dimen/activity_vertical_margin"
+                    app:cardCornerRadius="@dimen/default_card_corner_radius">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/tvEstimation"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_margin="10dp"
+                            android:text="4:16:23 h for 42.195 km (6:04 min/km)"
+                            android:textAlignment="center" />
+
+                        <TextView
+                            android:id="@+id/tvGoalDate"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_margin="10dp"
+                            android:text="You are expected to reach your goal on 23rd February 2024"
+                            android:textAlignment="center" />
+
+                    </LinearLayout>
+
+                </androidx.cardview.widget.CardView>
+
+                <TextView
+                    style="@style/TitleText"
+                    android:id="@+id/tvSuggestions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/default_horizontal_margin"
+                    android:layout_marginBottom="@dimen/activity_vertical_margin"
+                    android:text="@string/suggestions" />
+
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rvSuggestions"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/default_horizontal_margin" />
+
+            </LinearLayout>
+
+        </androidx.core.widget.NestedScrollView>
+
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <TextView
+        android:id="@+id/tvEmptyState"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/empty_state_margin"
+        android:text="@string/progression_empty_state"
+        android:textAlignment="center"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:visibility="gone"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_home_list_goal.xml
+++ b/app/src/main/res/layout/item_home_list_goal.xml
@@ -36,8 +36,8 @@
 
         <ImageView
             android:id="@+id/ivTime"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/timer_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvTime"
@@ -55,8 +55,8 @@
 
         <ImageView
             android:id="@+id/ivDistance"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/distance_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvDistance"
@@ -74,8 +74,8 @@
 
         <ImageView
             android:id="@+id/ivEstimation"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:src="@drawable/calculator_svgrepo_com"
             app:layout_constraintBottom_toBottomOf="@+id/ivTime"
             app:layout_constraintStart_toStartOf="@+id/guideline2"
@@ -93,8 +93,8 @@
 
         <ImageView
             android:id="@+id/ivDate"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:src="@drawable/baseline_calendar_today_24"
             app:layout_constraintBottom_toBottomOf="@+id/ivDistance"
             app:layout_constraintStart_toStartOf="@+id/guideline2"

--- a/app/src/main/res/layout/item_home_list_info.xml
+++ b/app/src/main/res/layout/item_home_list_info.xml
@@ -25,8 +25,8 @@
 
         <ImageView
             android:id="@+id/ivHeight"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/height_line_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvHeight"
@@ -44,8 +44,8 @@
 
         <ImageView
             android:id="@+id/ivWeight"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/weight_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvWeight"
@@ -63,8 +63,8 @@
 
         <ImageView
             android:id="@+id/ivBirthdate"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/baseline_calendar_today_24"
             app:layout_constraintStart_toEndOf="@+id/ivRunning"
@@ -82,8 +82,8 @@
 
         <ImageView
             android:id="@+id/ivRunning"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:src="@drawable/run_svgrepo_com"
             app:layout_constraintBottom_toBottomOf="@+id/ivRunningDate"
             app:layout_constraintStart_toStartOf="@+id/guideline2"
@@ -91,8 +91,8 @@
 
         <ImageView
             android:id="@+id/ivRunningDate"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/baseline_calendar_today_24"
             app:layout_constraintStart_toEndOf="@+id/ivRunning"

--- a/app/src/main/res/layout/item_home_list_training.xml
+++ b/app/src/main/res/layout/item_home_list_training.xml
@@ -46,8 +46,8 @@
 
         <ImageView
             android:id="@+id/ivDistance"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/distance_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvDistance"
@@ -65,8 +65,8 @@
 
         <ImageView
             android:id="@+id/ivRest"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/letter_zz_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvRest"
@@ -84,8 +84,8 @@
 
         <ImageView
             android:id="@+id/ivTime"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/timer_svgrepo_com"
             app:layout_constraintStart_toStartOf="@+id/guideline2"
@@ -103,8 +103,8 @@
 
         <ImageView
             android:id="@+id/ivHeart"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/baseline_favorite_border_24"
             app:layout_constraintStart_toStartOf="@+id/guideline2"

--- a/app/src/main/res/layout/item_list_label.xml
+++ b/app/src/main/res/layout/item_list_label.xml
@@ -12,7 +12,6 @@
         android:layout_marginStart="5dp"
         android:layout_marginTop="5dp"
         android:text="Notifications"
-        android:textSize="25dp"
-        android:textStyle="bold"/>
+        style="@style/TitleText"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/item_sessions_list.xml
+++ b/app/src/main/res/layout/item_sessions_list.xml
@@ -26,8 +26,8 @@
 
         <ImageView
             android:id="@+id/ivDistance"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/distance_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvDistance"
@@ -45,8 +45,8 @@
 
         <ImageView
             android:id="@+id/ivRest"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/letter_zz_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvRest"
@@ -66,8 +66,8 @@
 
         <ImageView
             android:id="@+id/ivPace"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/speedometer_svgrepo_com"
             app:layout_constraintEnd_toStartOf="@+id/tvPace"
@@ -87,8 +87,8 @@
 
         <ImageView
             android:id="@+id/ivTime"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/timer_svgrepo_com"
             app:layout_constraintStart_toStartOf="@+id/guideline2"
@@ -106,8 +106,8 @@
 
         <ImageView
             android:id="@+id/ivHeart"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="@dimen/icon_size"
+            android:layout_height="@dimen/icon_size"
             android:layout_marginTop="10dp"
             android:src="@drawable/baseline_favorite_border_24"
             app:layout_constraintStart_toStartOf="@+id/guideline2"

--- a/app/src/main/res/layout/item_suggestions_list.xml
+++ b/app/src/main/res/layout/item_suggestions_list.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_marginHorizontal="@dimen/default_horizontal_margin"
+    android:layout_marginBottom="@dimen/activity_vertical_margin"
+    app:cardCornerRadius="@dimen/default_card_corner_radius">
+
+    <TextView
+        android:id="@+id/tvSuggestion"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/default_horizontal_margin"
+        android:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
+        android:textAlignment="center"/>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_timeline_list.xml
+++ b/app/src/main/res/layout/item_timeline_list.xml
@@ -17,8 +17,8 @@
 
     <ImageView
         android:id="@+id/imageView"
-        android:layout_width="25dp"
-        android:layout_height="25dp"
+        android:layout_width="@dimen/icon_size"
+        android:layout_height="@dimen/icon_size"
         app:layout_constraintBottom_toTopOf="@+id/lowerSection"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/upperSection"

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -12,6 +12,11 @@
         android:title="@string/title_sessions" />
 
     <item
+        android:id="@+id/progressionFragment"
+        android:icon="@drawable/chart_icon"
+        android:title="@string/title_progression" />
+
+    <item
         android:id="@+id/settingsFragment"
         android:icon="@drawable/baseline_app_settings_alt_24"
         android:title="@string/title_settings" />

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -25,6 +25,11 @@
         <action
             android:id="@+id/action_homeFragment_to_suggestedSessionInfoFragment"
             app:destination="@id/suggestedSessionInfoFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_progressionFragment"
+            app:destination="@id/progressionFragment"
+            app:popUpTo="@id/homeFragment"
+            app:popUpToInclusive="true" />
     </fragment>
     <fragment
         android:id="@+id/settingsFragment"
@@ -77,4 +82,9 @@
             android:name="session"
             app:argType="com.example.healthconnect.codelab.domain.model.ditto.DittoGeneralInfo$TrainingSession" />
     </fragment>
+    <fragment
+        android:id="@+id/progressionFragment"
+        android:name="com.example.healthconnect.codelab.ui.progression.ProgressionFragment"
+        android:label="fragment_progression"
+        tools:layout="@layout/fragment_progression" />
 </navigation>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,4 +10,6 @@
 
     <dimen name="settings_card_corner_radius">10dp</dimen>
     <dimen name="settings_card_margin">5dp</dimen>
+
+    <dimen name="chart_height">300dp</dimen>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,4 +10,8 @@
 
     <dimen name="settings_card_corner_radius">10dp</dimen>
     <dimen name="settings_card_margin">5dp</dimen>
+
+    <dimen name="chart_height">300dp</dimen>
+
+    <dimen name="icon_size">25dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,4 +70,20 @@
 
     <!-- FATIGUE -->
     <string name="extreme_fatigue">You look extremely tired!\nRest is recommended</string>
+
+    <!-- PROGRESSION FRAGMENT -->
+    <string name="title_progression">Progression</string>
+    <string name="progression_empty_state">Sorry. There are no predictions available already. Please try again.</string>
+    <string name="current_estimation">Current Estimation</string>
+    <string name="suggestions">Suggestions</string>
+    <string name="estimation_part_1">for</string>
+    <string name="goal_date_part_1">You are expected to reach your goal on</string>
+    <string name="smaller_goal_1">You are not expected to reach the goal before the raceday. Would you like to change your goal to</string>
+    <string name="smaller_goal_2">for</string>
+    <string name="bigger_goal_1">You are expected to reach the goal before the raceday. Would you like to change your goal to</string>
+    <string name="bigger_goal_2">for</string>
+    <string name="less_training_days_1">You are expected to reach the goal before the raceday. Would you like to reduce the number of training days per week to</string>
+    <string name="less_training_days_2">days?</string>
+    <string name="more_training_days_1">You are not expected to reach the goal before the raceday. Would you like to increase the number of training days per week to</string>
+    <string name="more_training_days_2">days?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -70,4 +70,21 @@
 
     <!-- FATIGUE -->
     <string name="extreme_fatigue">You look extremely tired!\nRest is recommended</string>
+
+    <!-- PROGRESSION FRAGMENT -->
+    <string name="title_progression">Progression</string>
+    <string name="progression_empty_state">Sorry. There are no predictions available already. Please try again.</string>
+    <string name="current_estimation">Current Estimation</string>
+    <string name="suggestions">Suggestions</string>
+    <string name="estimation_part_1">for</string>
+    <string name="goal_date_part_1">You are expected to reach your goal on</string>
+    <string name="smaller_goal_1">You are not expected to reach the goal before the raceday. Would you like to change your goal to</string>
+    <string name="smaller_goal_2">for</string>
+    <string name="bigger_goal_1">You are expected to reach the goal before the raceday. Would you like to change your goal to</string>
+    <string name="bigger_goal_2">for</string>
+    <string name="less_training_days_1">You are expected to reach the goal before the raceday. Would you like to reduce the number of training days per week to</string>
+    <string name="less_training_days_2">days?</string>
+    <string name="more_training_days_1">You are not expected to reach the goal before the raceday. Would you like to increase the number of training days per week to</string>
+    <string name="more_training_days_2">days?</string>
+    <string name="put_features_success">User information have been updated successfully!</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="TitleText">
+        <item name="android:textSize">20sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/black</item>
+    </style>
+</resources>


### PR DESCRIPTION
Se ha añadido la pantalla de progresión.

Esta pantalla contiene una gráfica con las últimas predicciones.
Contiene una pequeña tarjeta en la que se indica la predicción actual y la fecha en la que está prevista que alcance el objetivo.
Por último también se pueden consultar las sugerencias y aplicarlas.

![progression_screen](https://github.com/artachojf/twinCoach/assets/100614773/5ece99b4-7e98-4abb-91a7-2b81e4521db1)

[Screen_recording_20240519_151519.webm](https://github.com/artachojf/twinCoach/assets/100614773/08817897-cd06-40e3-8383-768c91285820)
