### PR TITLE
FIX: Mean HR on Completed session

### DIFF
--- a/app/src/main/java/com/example/healthconnect/codelab/domain/model/ditto/DittoCurrentState.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/domain/model/ditto/DittoCurrentState.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneOffset
+import kotlin.math.roundToInt
 
 /**
  * This class contains a Kotlin object representation of Ditto Things that contain the daily
@@ -56,6 +57,16 @@ class DittoCurrentState {
         fun getTotalDistance(): Double = laps.sumOf { it.distance }
 
         fun getTotalTime(): Double = laps.sumOf { it.time }
+
+        fun meanHeartRate(): Int {
+            return try {
+                val total =
+                    (zone1.avgHr * zone1.time) + (zone2.avgHr * zone2.time) + (zone3.avgHr * zone3.time)
+                (total / (zone1.time + zone2.time + zone3.time)).roundToInt()
+            } catch (_: Exception) {
+                0
+            }
+        }
     }
 
     data class TrainingSessionZone(

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/sessions/calendar/SessionsCalendarFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/sessions/calendar/SessionsCalendarFragment.kt
@@ -98,7 +98,7 @@ class SessionsCalendarFragment : Fragment() {
         tvNextSession.text = session.attributes.date.toFormatString()
         tvDistance.text = distance.toInt().toDistanceString()
         tvTime.text = time.toInt().toTimeString()
-        tvHeart.text
+        tvHeart.text = session.features.trainingSession.meanHeartRate().toHeartRateString()
         tvPace.text = ((time/60) / (distance / 1000)).toSpeedString()
 
         ivPace.visibility = View.VISIBLE

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/sessions/info/completed/CompletedSessionInfoFragment.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/sessions/info/completed/CompletedSessionInfoFragment.kt
@@ -15,6 +15,7 @@ import com.example.healthconnect.codelab.ui.MainActivity
 import com.example.healthconnect.codelab.utils.round
 import com.example.healthconnect.codelab.utils.toDistanceString
 import com.example.healthconnect.codelab.utils.toFormatString
+import com.example.healthconnect.codelab.utils.toHeartRateString
 import com.example.healthconnect.codelab.utils.toSpeedString
 import com.example.healthconnect.codelab.utils.toTimeString
 
@@ -57,7 +58,7 @@ class CompletedSessionInfoFragment : Fragment() {
 
         tvDistance.text = distance.toInt().toDistanceString()
         tvTime.text = time.toInt().toTimeString()
-        tvHeart.text
+        tvHeart.text = session.meanHeartRate().toHeartRateString()
         tvPace.text = ((time/60) / (distance / 1000)).toSpeedString()
 
         tvNextSession.visibility = View.GONE

--- a/app/src/main/java/com/example/healthconnect/codelab/ui/sessions/list/adapter/SessionsListAdapter.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/ui/sessions/list/adapter/SessionsListAdapter.kt
@@ -79,7 +79,7 @@ class SessionsListAdapter(
                 tvNextSession.text = item.session.attributes.date.toFormatString()
                 tvDistance.text = distance.toInt().toDistanceString()
                 tvTime.text = time.toInt().toTimeString()
-                tvHeart.text
+                tvHeart.text = item.session.features.trainingSession.meanHeartRate().toHeartRateString()
                 tvPace.text = ((time/60) / (distance / 1000)).toSpeedString()
 
                 ivPace.visibility = View.VISIBLE


### PR DESCRIPTION
- Se ha arreglado el literal que muestra la frecuencia cardiaca media en las sesiones que ha completado el usuario.

![before](https://github.com/artachojf/twinCoach/assets/100614773/2d7c6a25-a166-4574-b3b0-66ea754b53d4)
![after](https://github.com/artachojf/twinCoach/assets/100614773/c1a47496-d3c5-4671-920d-69d36a5ff8ab)