### PR TITLE
FIX: Exception on health connect token expired

### DIFF
--- a/app/src/main/java/com/example/healthconnect/codelab/utils/healthConnect/HealthConnectManager.kt
+++ b/app/src/main/java/com/example/healthconnect/codelab/utils/healthConnect/HealthConnectManager.kt
@@ -198,22 +198,28 @@ class HealthConnectManager @Inject constructor(
         )
     }
 
+    sealed class GetChangesResult {
+        data class Success(val changes: List<Change>): GetChangesResult()
+        data class Error(val message: String): GetChangesResult()
+    }
+
     /**
      * Retrieve changes from a Changes token
      */
-    suspend fun getChanges(token: String): List<Change> {
+    suspend fun getChanges(token: String): GetChangesResult {
         var nextChangesToken = token
-        var changesList = ArrayList<Change>()
+        val changesList = ArrayList<Change>()
         do {
             val response = healthConnectClient.getChanges(nextChangesToken)
             if (response.changesTokenExpired) {
-                throw IOException("Changes token has expired")
+                //throw IOException("Changes token has expired")
+                return GetChangesResult.Error("Changes token has expired")
             }
             changesList.addAll(response.changes)
             nextChangesToken = response.nextChangesToken
         } while (response.hasMore)
 
-        return changesList
+        return GetChangesResult.Success(changesList)
     }
 
     /**


### PR DESCRIPTION
Se ha corregido la excepción que se lanzaba al detectar que el token de cambios de health connect había expirado.
En su lugar se retorna una sealed class que podrá ser de Success o Error, de esta manera se podrá procesar también en caso de error ya que no permitía haciendo un catch.